### PR TITLE
add hack folder back

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ testbin
 _all-built-manifests.yaml
 all-built-manifests.yaml
 iteration/node-tuning
-*.txt
 *.log
 transfer.sh
 kubectl
@@ -36,5 +35,3 @@ config-old/
 benchmarks/benchmark_operator/cpe_v1_benchmark_sysbench_*
 benchmarks/benchmark_operator/multi-cluster
 benchmarks/*/note*
-
-hack

--- a/hack/add_header.sh
+++ b/hack/add_header.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+for i in ../main.go ../*/*.go ../*/*/*.go # or whatever other pattern...
+do
+  if ! grep -q Copyright $i
+  then
+    cat boilerplate.go.txt $i >$i.new && mv $i.new $i
+  fi
+done

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,0 +1,6 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+ 


### PR DESCRIPTION
`boilerplate.go.txt` is used by controller-gen in MakeFile. 
Need to put hack folder back to the repo.