### PR TITLE
add kubeflow adaptor, time parser, fix bugs

### DIFF
--- a/benchmarks/none/cpe_parsec.yaml
+++ b/benchmarks/none/cpe_parsec.yaml
@@ -1,0 +1,42 @@
+apiVersion: cpe.cogadvisor.io/v1
+kind: Benchmark
+metadata:
+  name: parsec
+spec:
+  benchmarkOperator:
+    name: none
+    namespace: default
+  benchmarkSpec: |
+    template:
+      spec:
+        containers:
+        - name: parsec
+          image: sunyanan/parsec:v3.0
+          imagePullPolicy: Always
+          env:
+          - name: PACKAGE_ARG
+          - name: INPUT_ARG
+          command:
+          - bash
+          - -c
+          - 'parsecmgmt -a run -p ${PACKAGE_ARG} -i ${INPUT_ARG}'
+        restartPolicy: Never
+    backoffLimit: 4
+  parserKey: time
+  repetition: 5
+  interval: 5
+  iterationSpec:
+    iterations:
+    - name: input
+      location: ".template.spec.containers[0].env[name=INPUT_ARG].value"
+      values:
+      - "native"
+    - name: package
+      location: ".template.spec.containers[0].env[name=PACKAGE_ARG].value"
+      values:
+      - "bodytrack"
+      - "canneal"
+      - "raytrace"
+      - "ferret"
+    sequential: true
+    minimize: true

--- a/controllers/benchmarkoperator_controller.go
+++ b/controllers/benchmarkoperator_controller.go
@@ -126,8 +126,12 @@ func (r *BenchmarkOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		host := instance.Spec.CRD.Host
 		pathList := instance.Spec.CRD.Paths
 
+		gvk := GetSimpleJobGVK(instance)
+
 		var rules []rbacv1.PolicyRule
 		var apigroups []string
+		// init with job crd
+		apigroups = append(apigroups, gvk.Group)
 		for _, path := range pathList {
 			yamlURL := host + path
 			r.Log.Info(fmt.Sprintf("Create from yaml %s ", yamlURL))
@@ -155,13 +159,12 @@ func (r *BenchmarkOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				rules = append(rules, rule)
 			}
 		}
-		// add role for list, get, create, delete job resource
-		gvk := GetSimpleJobGVK(instance)
 
+		// add role for list, get, create, delete job resource
 		jobRule := rbacv1.PolicyRule{
 			APIGroups: []string{gvk.Group},
 			Verbs:     []string{"list", "get", "create", "delete", "watch"},
-			Resources: []string{gvk.Kind},
+			Resources: []string{rbacv1.ResourceAll},
 		}
 		rules = append(rules, jobRule)
 		r.Log.Info(fmt.Sprintf("Create job rule %v: %s,%s", jobRule, gvk.Group, gvk.Kind))

--- a/cpe-parser/api.go
+++ b/cpe-parser/api.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-/////////////////////////////////////////////
+// ///////////////////////////////////////////
 // add parser key -> module map here
 var codaitParser parser.Parser = parser.NewCodaitParser()
 var defaultParser parser.Parser = parser.NewDefaultParser()
@@ -30,6 +30,7 @@ var fioParser parser.Parser = parser.NewFioParser()
 var glooParser parser.Parser = parser.NewGlooParser()
 var gromacsParser parser.Parser = parser.NewGromacsParser()
 var linpackParser parser.Parser = parser.NewLinpackParser()
+var timeParser parser.Parser = parser.NewTimeParser()
 
 var parserMap map[string]parser.Parser = map[string]parser.Parser{
 	"codait":   codaitParser,
@@ -43,6 +44,7 @@ var parserMap map[string]parser.Parser = map[string]parser.Parser{
 	"gloo":     glooParser,
 	"gromacs":  gromacsParser,
 	"linpack":  linpackParser,
+	"time":     timeParser,
 }
 
 /////////////////////////////////////////////

--- a/cpe-parser/parser/osu.go
+++ b/cpe-parser/parser/osu.go
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
- package parser
+package parser
 
 import (
 	"bufio"

--- a/cpe-parser/parser/time.go
+++ b/cpe-parser/parser/time.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type TimeParser struct {
+	*BaseParser
+}
+
+/*
+  # OSU MPI
+  # Size          Latency (us)
+*/
+
+const (
+	RealTimeKey = "real"
+	UserTimeKey = "user"
+	SysTimeKey  = "sys"
+
+	performanceKey = "milliseconds"
+)
+
+func NewTimeParser() *TimeParser {
+	timeParser := &TimeParser{}
+	abs := &BaseParser{
+		Parser: timeParser,
+	}
+	timeParser.BaseParser = abs
+	return timeParser
+}
+
+func (p *TimeParser) parseTime(key, linestr string) (bool, int) {
+	match, err := regexp.MatchString(fmt.Sprintf("%s([\t\n\f\r ]+)([0-9]+(.)*([0-9])*)m([0-9]+(.)*([0-9])*)s", ""), linestr)
+	if err == nil && match {
+		values := strings.Fields(linestr)
+		if len(values) == 2 {
+			value := values[1]
+			mSplit := strings.Split(value[0:len(value)-1], "m")
+			minute, _ := strconv.ParseFloat(mSplit[0], 64)
+			second, _ := strconv.ParseFloat(mSplit[1], 64)
+			milliseconds := (second + minute*60) * 1000
+			return true, int(milliseconds)
+		}
+	}
+	return false, -1
+}
+
+func (p *TimeParser) ParseValue(body []byte) (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+	bytesReader := bytes.NewReader(body)
+	bufReader := bufio.NewReader(bytesReader)
+
+	for {
+		line, _, err := bufReader.ReadLine()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		linestr := string(line)
+		match, value := p.parseTime(RealTimeKey, linestr)
+		if match {
+			realTime := value
+			// next line
+			line, _, err = bufReader.ReadLine()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return nil, err
+			}
+			linestr = string(line)
+			match, value = p.parseTime(UserTimeKey, linestr)
+			if !match {
+				// something wrong
+				continue
+			}
+			userTime := value
+			// next line
+			line, _, err = bufReader.ReadLine()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return nil, err
+			}
+			linestr = string(line)
+			match, value = p.parseTime(SysTimeKey, linestr)
+			if !match {
+				// something wrong
+				continue
+			}
+			sysTime := value
+			labels := map[string]string{
+				"user": fmt.Sprintf("%d", userTime),
+				"sys":  fmt.Sprintf("%d", sysTime),
+			}
+			valueWithLabels := ValueWithLabels{
+				Labels: labels,
+				Value:  float64(realTime),
+			}
+			values[performanceKey] = valueWithLabels
+			break
+		}
+	}
+	return values, nil
+}
+
+func (p *TimeParser) GetPerformanceValue(values map[string]interface{}) (string, float64) {
+	if value, ok := values[performanceKey]; ok {
+		return performanceKey, value.(ValueWithLabels).Value
+	}
+	return "NoKey", -1
+}

--- a/cpe-parser/parser/time_test.go
+++ b/cpe-parser/parser/time_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+// Run go test -v parser/time_test.go
+
+package parser
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/IBM/cpe-operator/cpe-parser/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+// update log key here
+const (
+	LOG_KEY string = "time"
+)
+
+func getFileName() string {
+	return fmt.Sprintf("sample/%s_log.log", LOG_KEY)
+}
+
+var generalParser parser.Parser
+
+// update parser init function
+var testParser = parser.NewTimeParser()
+
+func TestParseValue(t *testing.T) {
+	fileName := getFileName()
+	bytes, err := ioutil.ReadFile(fileName)
+	generalParser = testParser
+	assert.Nil(t, err)
+	values, err := generalParser.ParseValue(bytes)
+	fmt.Printf("Values: %v\n", values)
+	assert.Nil(t, err)
+	// update assert value length
+	assert.Equal(t, len(values), 1)
+}
+
+func TestGetPerformanceValue(t *testing.T) {
+	fileName := getFileName()
+	bytes, err := ioutil.ReadFile(fileName)
+	generalParser = testParser
+	assert.Nil(t, err)
+	values, err := generalParser.ParseValue(bytes)
+	key, pvalue := testParser.GetPerformanceValue(values)
+	fmt.Printf("PKey: %s, Pvalue: %.2f\n", key, pvalue)
+	// update assert performance value
+	assert.NotEqual(t, pvalue, 61003)
+}


### PR DESCRIPTION
This PR includes the following changes:
- add `time` parser to parse output from linux time command
- add `parsec` benchmark example
- add adaptor for kubeflow pytorch job (https://github.com/IBM/cpe-operator/issues/7)
- always parse the result even if it cannot put log to COS in jobtracker
- delete all relevant pod not only the succeed pods in jobtracker
- check previousExist before replacement in jobtracker

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>