### PR TITLE
add stress parser

### DIFF
--- a/benchmarks/none/cpe_stress.yaml
+++ b/benchmarks/none/cpe_stress.yaml
@@ -1,0 +1,41 @@
+apiVersion: cpe.cogadvisor.io/v1
+kind: Benchmark
+metadata:
+  name: stressng
+spec:
+  benchmarkOperator:
+    name: none
+    namespace: default
+  benchmarkSpec: |
+    template:
+      spec:
+        containers:
+        - name: stress
+          image: alexeiled/stress-ng
+          imagePullPolicy: IfNotPresent
+          env:
+          - name: TIMEOUT
+            value: 60s
+          - name: STRESSOR
+          - name: STRESS_LOAD
+          command:
+          - /stress-ng
+          - --$(STRESSOR)
+          - $(STRESS_LOAD)
+          - --timeout
+          - $(TIMEOUT)
+          - --metrics-brief
+        restartPolicy: Never
+    backoffLimit: 4
+  parserKey: stress
+  repetition: 1
+  interval: 5
+  iterationSpec:
+    iterations:
+    - name: stressor
+      location: ".template.spec.containers[0].env[name=STRESSOR].value;.template.spec.containers[0].env[name=STRESS_LOAD].value"
+      values:
+      - "cpu;4"
+      - "io;4"
+      - "memcpy;4"
+    sequential: true

--- a/cpe-parser/parser/stress.go
+++ b/cpe-parser/parser/stress.go
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type StressParser struct {
+	*BaseParser
+}
+
+/*
+// stress-ng: info:  [1] stressor       bogo ops real time  usr time  sys time   bogo ops/s   bogo ops/s
+// stress-ng: info:  [1]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
+// stress-ng: info:  [1] cpu                4597      4.00     16.00      0.00      1147.95       287.31
+*/
+
+const (
+	StressKey = "stressor"
+)
+
+func NewStressParser() *StressParser {
+	stressParser := &StressParser{}
+	abs := &BaseParser{
+		Parser: stressParser,
+	}
+	stressParser.BaseParser = abs
+	return stressParser
+}
+
+func (p *StressParser) parseColumn(columnLine1, columnLine2 string) []string {
+	names := strings.Fields(columnLine1)
+	re := regexp.MustCompile(`\([^(\n]+\)`)
+	units := re.FindAllString(columnLine2, -1)
+	columns := []string{}
+	column := ""
+	unitIndex := 0
+	for _, name := range names {
+		if strings.Contains(name, "ops") || strings.Contains(name, "time") {
+			column = fmt.Sprintf("%s %s", column, name)
+			if name != "ops" && unitIndex < len(units) {
+				// has unit
+				unit := units[unitIndex]
+				unit = strings.ReplaceAll(unit, "+", "/")
+				if strings.Contains(unit, "time") {
+					// add in front
+					column = fmt.Sprintf("%s %s", unit, column)
+				} else {
+					// add in back
+					column = fmt.Sprintf("%s %s", column, unit)
+				}
+				unitIndex += 1
+			}
+			columns = append(columns, column)
+		} else {
+			column = name
+		}
+	}
+	return columns
+}
+
+func (p *StressParser) ParseValue(body []byte) (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+	bytesReader := bytes.NewReader(body)
+	bufReader := bufio.NewReader(bytesReader)
+	started := false
+	prefix := ""
+	var columns []string
+	for {
+		line, _, err := bufReader.ReadLine()
+		linestr := string(line)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		if !started {
+			if strings.Contains(linestr, StressKey) {
+				started = true
+				splited := strings.Split(linestr, StressKey)
+				prefix = splited[0]
+				columnLine1 := splited[1]
+				line, _, err := bufReader.ReadLine()
+				if err == io.EOF {
+					break
+				} else if err != nil {
+					return nil, err
+				}
+				// next coming line
+				columnLine2 := string(line)
+				columns = p.parseColumn(columnLine1, columnLine2)
+			}
+		} else {
+			if strings.Contains(linestr, prefix) {
+				splited := strings.Fields(linestr[len(prefix) : len(linestr)-1])
+				if len(splited) == len(columns)+1 { // first split is stressor
+					for index, column := range columns {
+						value, err := strconv.ParseFloat(splited[index+1], 64)
+						if err == nil {
+							key := fmt.Sprintf("%s %s", splited[0], column)
+							values[key] = value
+						}
+					}
+				}
+			}
+		}
+	}
+	return values, nil
+}
+
+func (p *StressParser) GetPerformanceValue(values map[string]interface{}) (string, float64) {
+	keys := make([]string, len(values))
+	i := 0
+	for key := range values {
+		keys[i] = key
+		i += 1
+	}
+	fmt.Println(keys)
+	if len(keys) > 0 {
+		sort.Strings(keys)
+		return keys[0], values[keys[0]].(float64)
+	}
+	return "NoKey", -1
+}

--- a/cpe-parser/parser/stress_test.go
+++ b/cpe-parser/parser/stress_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+// Run go test -v parser/stress_test.go
+
+package parser
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/IBM/cpe-operator/cpe-parser/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+// update log key here
+const (
+	LOG_KEY string = "stress"
+)
+
+func getFileName() string {
+	return fmt.Sprintf("sample/%s_log.log", LOG_KEY)
+}
+
+var generalParser parser.Parser
+
+// update parser init function
+var testParser = parser.NewStressParser()
+
+func TestParseValue(t *testing.T) {
+	fileName := getFileName()
+	bytes, err := ioutil.ReadFile(fileName)
+	generalParser = testParser
+	assert.Nil(t, err)
+	values, err := generalParser.ParseValue(bytes)
+	fmt.Printf("Values: %v\n", values)
+	assert.Nil(t, err)
+	// update assert value length
+	assert.Equal(t, len(values), 24)
+}
+
+func TestGetPerformanceValue(t *testing.T) {
+	fileName := getFileName()
+	bytes, err := ioutil.ReadFile(fileName)
+	generalParser = testParser
+	assert.Nil(t, err)
+	values, err := generalParser.ParseValue(bytes)
+	key, pvalue := testParser.GetPerformanceValue(values)
+	fmt.Printf("PKey: %s, Pvalue: %.2f\n", key, pvalue)
+	// update assert performance value
+	assert.NotEqual(t, pvalue, 4597)
+}


### PR DESCRIPTION
This PR added stressng parser based on the format with `--metrics-brief` option.

example:
```
stress-ng: info:  [1] dispatching hogs: 4 cpu, 2 io, 1 memcpy, 1 vm
stress-ng: info:  [1] successful run completed in 4.04s
stress-ng: info:  [1] stressor       bogo ops real time  usr time  sys time   bogo ops/s   bogo ops/s
stress-ng: info:  [1]                           (secs)    (secs)    (secs)   (real time) (usr+sys time)
stress-ng: info:  [1] cpu                4597      4.00     16.00      0.00      1147.95       287.31
stress-ng: info:  [1] io                23795      4.00      0.14      7.15      5948.35      3264.06
stress-ng: info:  [1] memcpy             5167      4.00      4.00      0.00      1291.71      1291.75
stress-ng: info:  [1] vm                    0      4.04      3.60      0.43         0.00         0.00
```

In addition, this PR also include `ReqRawParse` regarding the merged PR https://github.com/IBM/cpe-operator/pull/9

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>
