### PR TITLE
Suppress soft error and remove dependency of pusher on operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 
-export IMAGE_REGISTRY ?= <your-repo>
+export IMAGE_REGISTRY ?= your-repo
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #

--- a/api/v1/benchmark_types.go
+++ b/api/v1/benchmark_types.go
@@ -65,6 +65,7 @@ type BenchmarkResultItem struct {
 	PodName          string `json:"pod"`
 	PerformanceKey   string `json:"performanceKey"`
 	PerformanceValue string `json:"performanceValue"`
+	Result           string `json:"parseResult"`
 	PushedTime       string `json:"pushedTime"`
 }
 

--- a/api/v1/groupversion_info.go
+++ b/api/v1/groupversion_info.go
@@ -4,8 +4,8 @@
  */
 
 // Package v1 contains API Schema definitions for the cpe v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=cpe.cogadvisor.io
+// +kubebuilder:object:generate=true
+// +groupName=cpe.cogadvisor.io
 package v1
 
 import (

--- a/config/crd/bases/cpe.cogadvisor.io_benchmarks.yaml
+++ b/config/crd/bases/cpe.cogadvisor.io_benchmarks.yaml
@@ -249,6 +249,8 @@ spec:
                         properties:
                           job:
                             type: string
+                          parseResult:
+                            type: string
                           performanceKey:
                             type: string
                           performanceValue:
@@ -261,6 +263,7 @@ spec:
                             type: string
                         required:
                         - job
+                        - parseResult
                         - performanceKey
                         - performanceValue
                         - pod

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -25,7 +25,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-#- ../prometheus
+- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/config/default/manager_cos_patch.yaml
+++ b/config/default/manager_cos_patch.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+  labels:
+    control-plane: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: CPE_COS_LOG_APIKEY
+          valueFrom:
+            secretKeyRef:
+              key: apiKey
+              name: cpe-cos-key
+        - name: CPE_COS_LOG_SERVICE_ID
+          valueFrom:
+            secretKeyRef:
+              key: serviceInstanceID
+              name: cpe-cos-key
+        - name: CPE_COS_LOG_AUTH_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              key: authEndpoint
+              name: cpe-cos-key
+        - name: CPE_COS_LOG_SERVICE_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              key: serviceEndpoint
+              name: cpe-cos-key
+        - name: CPE_COS_LOG_RAW_BUCKET
+          valueFrom:
+            secretKeyRef:
+              key: rawBucketName
+              name: cpe-cos-key

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -12,5 +12,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: res-cpe-team-docker-local.artifactory.swg-devops.com/cpe/operator-controller
+  newName: your-repo/cpe/operator-controller
   newTag: v0.0.1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,35 +26,14 @@ spec:
         runAsNonRoot: true
       containers:
       - env:
-        - name: CPE_COS_LOG_APIKEY
-          valueFrom:
-            secretKeyRef:
-              key: apiKey
-              name: cpe-cos-key
-        - name: CPE_COS_LOG_SERVICE_ID
-          valueFrom:
-            secretKeyRef:
-              key: serviceInstanceID
-              name: cpe-cos-key
-        - name: CPE_COS_LOG_AUTH_ENDPOINT
-          valueFrom:
-            secretKeyRef:
-              key: authEndpoint
-              name: cpe-cos-key
-        - name: CPE_COS_LOG_SERVICE_ENDPOINT
-          valueFrom:
-            secretKeyRef:
-              key: serviceEndpoint
-              name: cpe-cos-key
-        - name: CPE_COS_LOG_RAW_BUCKET
-          valueFrom:
-            secretKeyRef:
-              key: rawBucketName
-              name: cpe-cos-key
         - name: PARSER_SERVICE
           value: http://cpe-operator-cpe-parser.cpe-operator-system
         - name: CLUSTER_ID
-          value: eks-tokyo
+          value: cpang
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: tuned-search-space
           mountPath: /etc/search-space
@@ -92,5 +71,3 @@ spec:
           name: node-tuning-search-space
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
-      imagePullSecrets:
-      - name: res-cpe-team-docker-local

--- a/config/manager/manager_template.yaml
+++ b/config/manager/manager_template.yaml
@@ -26,35 +26,14 @@ spec:
         runAsNonRoot: true
       containers:
       - env:
-        - name: CPE_COS_LOG_APIKEY
-          valueFrom:
-            secretKeyRef:
-              key: apiKey
-              name: ${COS_SECRET}
-        - name: CPE_COS_LOG_SERVICE_ID
-          valueFrom:
-            secretKeyRef:
-              key: serviceInstanceID
-              name: ${COS_SECRET}
-        - name: CPE_COS_LOG_AUTH_ENDPOINT
-          valueFrom:
-            secretKeyRef:
-              key: authEndpoint
-              name: ${COS_SECRET}
-        - name: CPE_COS_LOG_SERVICE_ENDPOINT
-          valueFrom:
-            secretKeyRef:
-              key: serviceEndpoint
-              name: ${COS_SECRET}
-        - name: CPE_COS_LOG_RAW_BUCKET
-          valueFrom:
-            secretKeyRef:
-              key: rawBucketName
-              name: ${COS_SECRET}
         - name: PARSER_SERVICE
           value: http://cpe-operator-cpe-parser.cpe-operator-system
         - name: CLUSTER_ID
           value: ${CLUSTER_ID}
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - name: tuned-search-space
           mountPath: /etc/search-space
@@ -92,5 +71,3 @@ spec:
           name: node-tuning-search-space
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
-      imagePullSecrets:
-      - name: ${PULL_SECRET}

--- a/config/parser/parser.yaml
+++ b/config/parser/parser.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cpe-parser
-          image: <your-repo>/cpe/parser:v0.0.1
+          image: your-repo/cpe/parser:v0.0.1
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
 - monitor.yaml
+- rbac.yaml

--- a/config/prometheus/rbac.yaml
+++ b/config/prometheus/rbac.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: prometheus
+  name: prometheus-k8s
+  namespace: system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: prometheus
+    app.kubernetes.io/instance: k8s
+    app.kubernetes.io/name: prometheus
+  name: prometheus-k8s
+  namespace: system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring

--- a/controllers/benchmark_controller.go
+++ b/controllers/benchmark_controller.go
@@ -91,13 +91,13 @@ func (r *BenchmarkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if is_deleted {
 		if controllerutil.ContainsFinalizer(instance, benchmarkFinalizer) {
 			if err := r.finalizeBenchmark(reqLogger, instance); err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, nil
 			}
 
 			controllerutil.RemoveFinalizer(instance, benchmarkFinalizer)
 			err := r.Client.Update(ctx, instance)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{}, nil
 			}
 		}
 		return ctrl.Result{}, nil
@@ -108,7 +108,7 @@ func (r *BenchmarkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		controllerutil.AddFinalizer(instance, benchmarkFinalizer)
 		err = r.Client.Update(ctx, instance)
 		if err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 	} else {
 		r.Log.Info(fmt.Sprintf("Creating #%s ", instance.ObjectMeta.Name))
@@ -121,7 +121,7 @@ func (r *BenchmarkReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		err = r.Client.Get(ctx, types.NamespacedName{Name: operatorName, Namespace: operatorNS}, operator)
 		if err != nil {
 			r.Log.Info(fmt.Sprintf("Cannot get #%v ", err))
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 		var adaptor OperatorAdaptor
 		if _, adaptorExists := OperatorAdaptorMap[operator.Spec.Adaptor]; adaptorExists {

--- a/controllers/collector.go
+++ b/controllers/collector.go
@@ -1,0 +1,192 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	cpev1 "github.com/IBM/cpe-operator/api/v1"
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	cpe_result_metric_name   = "cpe_result_val"
+	cpe_result_metric_lables = []string{
+		"benchmark", "build", "config", "scenario", "job", "pod", "key", "attrbs",
+	}
+)
+
+type ValueWithLabels struct {
+	Labels map[string]string
+	Value  float64
+}
+type ValuesWithLabels struct {
+	Labels map[string]string
+	Values []float64
+}
+
+type ResultCollector struct {
+	client.Client
+	Log           logr.Logger
+	resultVectors *prometheus.GaugeVec
+}
+
+func (c *ResultCollector) relabelKey(key string) string {
+	key = strings.ToLower(key)
+	key = strings.ReplaceAll(key, " ", "_")
+	key = strings.ReplaceAll(key, "(", "_")
+	key = strings.ReplaceAll(key, "/", "_per_")
+	key = strings.ReplaceAll(key, ")", "")
+	key = strings.ReplaceAll(key, "%", "_percent")
+	key = strings.ReplaceAll(key, "__", "_")
+	return key
+}
+
+func (c *ResultCollector) labelMapToStr(labelMap map[string]string) string {
+	keys := []string{}
+	for k := range labelMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	str := ""
+	for index, k := range keys {
+		if index > 0 {
+			str += "_"
+		}
+		str += fmt.Sprintf("%s_%s ", k, labelMap[k])
+	}
+	return strings.ToLower(str)
+}
+
+func NewCollector(client client.Client, logger logr.Logger) {
+	collector := &ResultCollector{
+		Client: client,
+		Log:    logger,
+		resultVectors: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: cpe_result_metric_name,
+			Help: "CPE Results with parsed key and index if applicable",
+		}, cpe_result_metric_lables),
+	}
+	// register prometheus
+	metrics.Registry.MustRegister(collector)
+}
+
+// Describe implements the prometheus.Collector interface
+func (c *ResultCollector) Describe(ch chan<- *prometheus.Desc) {
+	c.resultVectors.Describe(ch)
+}
+
+func (c *ResultCollector) getStat(vals []float64) (minVal, maxVal, avgVal float64) {
+	if len(vals) == 0 {
+		// no values
+		return -1, -1, -1
+	}
+	minVal = vals[0]
+	maxVal = vals[0]
+	var sumVal float64 = 0
+	for _, val := range vals {
+		if val > maxVal {
+			maxVal = val
+		} else if val < minVal {
+			minVal = val
+		}
+		sumVal += val
+	}
+	avgVal = sumVal / float64(len(vals))
+	return
+}
+
+func (c *ResultCollector) getCommonLabels(benchmarkName, build, configID, scenarioID, jobName, podName string) prometheus.Labels {
+	labels := make(prometheus.Labels)
+	labels["benchmark"] = benchmarkName
+	labels["build"] = build
+	labels["config"] = configID
+	labels["scenario"] = scenarioID
+	labels["job"] = jobName
+	labels["pod"] = podName
+	return labels
+}
+
+func (c *ResultCollector) updateGaugeVec(benchmarkName, build, configID, scenarioID, jobName, podName string, values map[string]interface{}) {
+	for key, vals := range values {
+		relabeledKey := c.relabelKey(key)
+		if reflect.TypeOf(vals).Kind() == reflect.Float64 {
+			labels := c.getCommonLabels(benchmarkName, build, configID, scenarioID, jobName, podName)
+			labels["key"] = relabeledKey
+			labels["attrbs"] = ""
+			c.resultVectors.With(labels).Set(vals.(float64))
+		} else if valueWithLabelsArr, ok := vals.([]ValueWithLabels); ok {
+			for _, valueWithLabels := range valueWithLabelsArr {
+				labels := c.getCommonLabels(benchmarkName, build, configID, scenarioID, jobName, podName)
+				labels["key"] = relabeledKey
+				labels["attrbs"] = c.labelMapToStr(valueWithLabels.Labels)
+				c.resultVectors.With(labels).Set(valueWithLabels.Value)
+			}
+		} else if valuesWithLabelsArr, ok := vals.([]ValuesWithLabels); ok {
+			for _, valuesWithLabels := range valuesWithLabelsArr {
+				minVal, maxVal, avgVal := c.getStat(valuesWithLabels.Values)
+				minLabels := c.getCommonLabels(benchmarkName, build, configID, scenarioID, jobName, podName)
+				maxLables := c.getCommonLabels(benchmarkName, build, configID, scenarioID, jobName, podName)
+				avgLables := c.getCommonLabels(benchmarkName, build, configID, scenarioID, jobName, podName)
+				minLabels["key"] = relabeledKey
+				maxLables["key"] = relabeledKey
+				avgLables["key"] = relabeledKey
+				minLabels["attrbs"] = c.labelMapToStr(valuesWithLabels.Labels) + "_min"
+				maxLables["attrbs"] = c.labelMapToStr(valuesWithLabels.Labels) + "_max"
+				avgLables["attrbs"] = c.labelMapToStr(valuesWithLabels.Labels) + "_avg"
+				c.resultVectors.With(minLabels).Set(minVal)
+				c.resultVectors.With(maxLables).Set(maxVal)
+				c.resultVectors.With(avgLables).Set(avgVal)
+			}
+		} else if reflect.TypeOf(vals).Kind() == reflect.Slice {
+			for index, val := range vals.([]interface{}) {
+				if reflect.TypeOf(val).Kind() == reflect.Float64 {
+					labels := c.getCommonLabels(benchmarkName, build, configID, scenarioID, jobName, podName)
+					labels["key"] = relabeledKey
+					labels["attrbs"] = fmt.Sprintf("%d", index)
+					c.resultVectors.With(labels).Set(val.(float64))
+				}
+			}
+		} else {
+			c.Log.Info(fmt.Sprintf("Wrong key type: %v", vals))
+		}
+	}
+}
+
+// Collect implements the prometheus.Collector interface
+// "benchmark", "build", "configID", "scenarioID", "job", "pod", "key", "index"
+func (c *ResultCollector) Collect(ch chan<- prometheus.Metric) {
+	benchmarks := &cpev1.BenchmarkList{}
+	c.Client.List(context.TODO(), benchmarks, &client.ListOptions{
+		Namespace: metav1.NamespaceAll,
+	})
+	for _, benchmark := range benchmarks.Items {
+		benchmarkName := benchmark.Name
+		for _, result := range benchmark.Status.Results {
+			build := result.BuildID
+			configID := result.ConfigurationID
+			scenarioID := result.IterationID
+			for _, item := range result.Items {
+				values := make(map[string]interface{})
+				err := json.Unmarshal([]byte(item.Result), &values)
+				if err != nil {
+					c.Log.Info(fmt.Sprintf("Cannot parse values of %s from respone: %s", benchmarkName, item.Result))
+					continue
+				}
+				jobName := item.JobName
+				podName := item.PodName
+				c.updateGaugeVec(benchmarkName, build, configID, scenarioID, jobName, podName, values)
+			}
+		}
+	}
+	c.resultVectors.Collect(ch)
+}

--- a/controllers/iteration.go
+++ b/controllers/iteration.go
@@ -257,7 +257,9 @@ func (it *IterationHandler) UpdateValue(baseObject map[string]interface{}, locat
 
 	var modifiedObject map[string]interface{}
 	for index, locationSplits := range locationSplitsArr {
-		modifiedObject = it.updateNextValue(baseObject, locationSplits, 0, values[index])
+		if index < len(values) {
+			modifiedObject = it.updateNextValue(baseObject, locationSplits, 0, values[index])
+		}
 	}
 	return modifiedObject
 }

--- a/controllers/job_tracker.go
+++ b/controllers/job_tracker.go
@@ -395,6 +395,7 @@ func (r *JobTracker) updateBenchmarkStatus(benchmark *cpev1.Benchmark, jobName s
 		Repetition:       repetition,
 		PerformanceKey:   performanceKey,
 		PerformanceValue: pvalInString,
+		Result:           response.Message,
 		JobName:          jobName,
 		PodName:          podName,
 		PushedTime:       pushedTime,

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/mittwald/go-helm-client v0.5.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
+	github.com/prometheus/client_golang v1.7.1
+	github.com/prometheus/common v0.10.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect


### PR DESCRIPTION
This PR suppresses fatal throw when there is an human error defined in benchmark CR including:
- define benchmark with not-found operator 
- unequal number of values to labels in conjunction case (with `;` delimiter)

Related to the first common error when try deploying basic job spec, this PR also includes the code to deploy NoneOperator (some part pre-implemented in PR https://github.com/IBM/cpe-operator/pull/10).

Also, this PR improves the CPE operator to export all performance metrics without requirement of COS or PushGateway , corresponding to the PR https://github.com/IBM/cpe-operator/pull/9. 

Example raw result on prometheus:
<img width="1719" alt="Screenshot 2023-04-05 at 18 26 40" src="https://user-images.githubusercontent.com/11749848/230040159-908d8b6f-0a37-4cff-bcbc-2aa4a284c647.png">


Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>