### PR TITLE
Add mlperf and fmwork parser

### DIFF
--- a/cpe-parser/api.go
+++ b/cpe-parser/api.go
@@ -32,6 +32,7 @@ var gromacsParser parser.Parser = parser.NewGromacsParser()
 var linpackParser parser.Parser = parser.NewLinpackParser()
 var timeParser parser.Parser = parser.NewTimeParser()
 var stressParser parser.Parser = parser.NewStressParser()
+var mlperfParser parser.Parser = parser.NewMlPerfParser()
 
 var parserMap map[string]parser.Parser = map[string]parser.Parser{
 	"codait":   codaitParser,
@@ -47,6 +48,7 @@ var parserMap map[string]parser.Parser = map[string]parser.Parser{
 	"linpack":  linpackParser,
 	"time":     timeParser,
 	"stress":   stressParser,
+	"mlperf":   mlperfParser,
 }
 
 /////////////////////////////////////////////

--- a/cpe-parser/api.go
+++ b/cpe-parser/api.go
@@ -33,6 +33,7 @@ var linpackParser parser.Parser = parser.NewLinpackParser()
 var timeParser parser.Parser = parser.NewTimeParser()
 var stressParser parser.Parser = parser.NewStressParser()
 var mlperfParser parser.Parser = parser.NewMlPerfParser()
+var fmworkParser parser.Parser = parser.NewFMWorkParser()
 
 var parserMap map[string]parser.Parser = map[string]parser.Parser{
 	"codait":   codaitParser,
@@ -49,6 +50,7 @@ var parserMap map[string]parser.Parser = map[string]parser.Parser{
 	"time":     timeParser,
 	"stress":   stressParser,
 	"mlperf":   mlperfParser,
+	"fmwork":   fmworkParser,
 }
 
 /////////////////////////////////////////////

--- a/cpe-parser/parser/common.go
+++ b/cpe-parser/parser/common.go
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package parser
+
+const (
+	BIGLINE = "===================================="
+)

--- a/cpe-parser/parser/fmwork.go
+++ b/cpe-parser/parser/fmwork.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type FMWorkParser struct {
+	*BaseParser
+}
+
+/*
+Tokens per iteration: 2
+
+               s/iter           seqs/s         tokens/s         ms/token
+MIN       0.031715076     31.530745819     63.061491639     15.857538000
+MAX       1.158101110      0.863482464      1.726964928    579.050555000
+AVG       0.034738420     28.786571393     57.573142786     17.369209871
+MED       0.031836234     31.410750898     62.821501796     15.918116750
+P95       0.032091481     31.160917510     62.321835020     16.045740625
+STD       0.056241701
+*/
+
+const (
+	FMWorkPerfKey = "Tokens per iteration"
+)
+
+func NewFMWorkParser() *FMWorkParser {
+	fmworkParser := &FMWorkParser{}
+	abs := &BaseParser{
+		Parser: fmworkParser,
+	}
+	fmworkParser.BaseParser = abs
+	return fmworkParser
+}
+
+func (p *FMWorkParser) ParseValue(body []byte) (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+
+	bytesReader := bytes.NewReader(body)
+	bufReader := bufio.NewReader(bytesReader)
+	for {
+		line, _, err := bufReader.ReadLine()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		linestr := string(line)
+		if strings.Contains(linestr, FMWorkPerfKey) {
+			// start from here // Tokens per iteration
+			splitedLine := strings.Split(linestr, ":")
+			if len(splitedLine) == 2 {
+				valueStr := strings.TrimSpace(splitedLine[1])
+				key := strings.TrimSpace(splitedLine[0])
+				value, err := strconv.ParseFloat(valueStr, 64)
+				if err == nil {
+					values[key] = value
+				}
+			}
+			// skip one line
+			_, _, err := bufReader.ReadLine()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return nil, err
+			}
+			line, _, err := bufReader.ReadLine()
+			if err == io.EOF {
+				break
+			} else if err != nil {
+				return nil, err
+			}
+			headers_line := string(line)
+			headers := strings.Fields(headers_line)
+			for {
+				line, _, err := bufReader.ReadLine()
+				if err == io.EOF {
+					break
+				} else if err != nil {
+					return nil, err
+				}
+				linestr := string(line)
+				valueStrs := strings.Fields(linestr)
+				if len(valueStrs) > 1 {
+					for index, valueStr := range valueStrs[1:] {
+						key := fmt.Sprintf("%s %s", strings.ToLower(valueStrs[0]), headers[index])
+						value, err := strconv.ParseFloat(valueStr, 64)
+						if err == nil {
+							values[key] = value
+						}
+					}
+				}
+			}
+			// end
+			break
+		}
+	}
+	return values, nil
+}
+
+func (p *FMWorkParser) GetPerformanceValue(values map[string]interface{}) (string, float64) {
+	candidatePerformanceStatKeys := []string{"p95", "p90", "p99", "avg"}
+	for _, performanceStatKey := range candidatePerformanceStatKeys {
+		performanceKey := fmt.Sprintf("%s s/iter", performanceStatKey)
+		if value, ok := values[performanceKey]; ok {
+			return performanceKey, value.(float64)
+		}
+	}
+
+	return "NoKey", -1
+}

--- a/cpe-parser/parser/fmwork_test.go
+++ b/cpe-parser/parser/fmwork_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+// Run go test -v parser/fmwork_test.go
+
+package parser
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/IBM/cpe-operator/cpe-parser/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+// update log key here
+const (
+	LOG_KEY string = "fmwork"
+)
+
+func getFileName() string {
+	return fmt.Sprintf("sample/%s_pod_log.log", LOG_KEY)
+}
+
+var generalParser parser.Parser
+
+// update parser init function
+var testParser = parser.NewFMWorkParser()
+
+func TestParseValue(t *testing.T) {
+	fileName := getFileName()
+	bytes, err := ioutil.ReadFile(fileName)
+	generalParser = testParser
+	assert.Nil(t, err)
+	values, err := generalParser.ParseValue(bytes)
+	fmt.Printf("Values: %v\n", values)
+	assert.Nil(t, err)
+	// update assert value length
+	assert.Equal(t, len(values), 22)
+}
+
+func TestGetPerformanceValue(t *testing.T) {
+	fileName := getFileName()
+	bytes, err := ioutil.ReadFile(fileName)
+	generalParser = testParser
+	assert.Nil(t, err)
+	values, err := generalParser.ParseValue(bytes)
+	key, pvalue := testParser.GetPerformanceValue(values)
+	fmt.Printf("PKey: %s, Pvalue: %.2f\n", key, pvalue)
+	// update assert performance value
+	assert.Equal(t, pvalue, 0.032091481)
+}

--- a/cpe-parser/parser/gloo.go
+++ b/cpe-parser/parser/gloo.go
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache2.0
  */
 
- package parser
+package parser
 
 import (
 	"bufio"
@@ -18,12 +18,11 @@ type GlooParser struct {
 }
 
 /*
-# OSU MPI
-# Size          Latency (us)
+ # OSU MPI
+ # Size          Latency (us)
 */
 
 const (
-	GLOOLINE             = "===================================================================================================="
 	GLOO_PERFORMANCE_KEY = "bandwidth_GBps"
 )
 
@@ -53,7 +52,7 @@ func (p *GlooParser) ParseValue(body []byte) (map[string]interface{}, error) {
 			return nil, err
 		}
 		if linecount < 2 {
-			if strings.Contains(linestr, GLOOLINE) {
+			if strings.Contains(linestr, BIGLINE) {
 				linecount += 1
 			}
 		} else {

--- a/cpe-parser/parser/mlperf.go
+++ b/cpe-parser/parser/mlperf.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strconv"
+	"strings"
+)
+
+type MlPerfParser struct {
+	*BaseParser
+}
+
+/*
+================================================
+MLPerf Results Summary
+================================================
+SUT name : PySUT
+Scenario : Offline
+Mode : PerformanceOnly
+Samples per second: 1196.99
+Result is : INVALID
+Min duration satisfied : NO
+Min queries satisfied : Yes
+Early stopping satisfied: Yes
+Recommendations:
+* Increase expected QPS so the loadgen pre-generates a larger (coalesced) query.
+
+*/
+
+const (
+	MlPerfSummarySession  = "MLPerf Results Summary"
+	AdditionalStatSession = "Additional Stats"
+)
+
+func NewMlPerfParser() *MlPerfParser {
+	mlperfParser := &MlPerfParser{}
+	abs := &BaseParser{
+		Parser: mlperfParser,
+	}
+	mlperfParser.BaseParser = abs
+	return mlperfParser
+}
+
+func (p *MlPerfParser) ParseValue(body []byte) (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+
+	session := ""
+
+	bytesReader := bytes.NewReader(body)
+	bufReader := bufio.NewReader(bytesReader)
+	for {
+		line, _, err := bufReader.ReadLine()
+		linestr := string(line)
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		if session == "" {
+			if strings.Contains(linestr, MlPerfSummarySession) {
+				session = MlPerfSummarySession
+			} else if strings.Contains(linestr, AdditionalStatSession) {
+				session = AdditionalStatSession
+			}
+			if session != "" {
+				_, _, err := bufReader.ReadLine()
+				if err == io.EOF {
+					break
+				} else if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			if strings.Contains(linestr, BIGLINE) {
+				session = ""
+				continue
+			}
+			splitedLine := strings.Split(linestr, ":")
+			if len(splitedLine) != 2 {
+				continue
+			}
+			valueStr := strings.TrimSpace(splitedLine[1])
+			key := strings.TrimSpace(splitedLine[0])
+			value, err := strconv.ParseFloat(valueStr, 64)
+			if err == nil {
+				values[key] = value
+			}
+		}
+	}
+	return values, nil
+}
+
+func (p *MlPerfParser) GetPerformanceValue(values map[string]interface{}) (string, float64) {
+	performanceKey := "Samples per second"
+	if value, ok := values[performanceKey]; ok {
+		return performanceKey, value.(float64)
+	}
+	return "NoKey", -1
+}

--- a/cpe-parser/parser/mlperf_test.go
+++ b/cpe-parser/parser/mlperf_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022- IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache2.0
+ */
+
+// Run go test -v parser/mlperf_test.go
+
+package parser
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/IBM/cpe-operator/cpe-parser/parser"
+	"github.com/stretchr/testify/assert"
+)
+
+// update log key here
+const (
+	LOG_KEY string = "mlperf"
+)
+
+func getFileName() string {
+	return fmt.Sprintf("sample/%s_pod_log.log", LOG_KEY)
+}
+
+var generalParser parser.Parser
+
+// update parser init function
+var testParser = parser.NewMlPerfParser()
+
+func TestParseValue(t *testing.T) {
+	fileName := getFileName()
+	bytes, err := ioutil.ReadFile(fileName)
+	generalParser = testParser
+	assert.Nil(t, err)
+	values, err := generalParser.ParseValue(bytes)
+	fmt.Printf("Values: %v\n", values)
+	assert.Nil(t, err)
+	// update assert value length
+	assert.Equal(t, len(values), 10)
+}
+
+func TestGetPerformanceValue(t *testing.T) {
+	fileName := getFileName()
+	bytes, err := ioutil.ReadFile(fileName)
+	generalParser = testParser
+	assert.Nil(t, err)
+	values, err := generalParser.ParseValue(bytes)
+	key, pvalue := testParser.GetPerformanceValue(values)
+	fmt.Printf("PKey: %s, Pvalue: %.2f\n", key, pvalue)
+	// update assert performance value
+	assert.Equal(t, pvalue, 1196.99)
+}


### PR DESCRIPTION
This PR introduces two new parsers: mlperf and fmwork.

```bash
> go test -v parser/mlperf_test.go
=== RUN   TestParseValue
Values: map[50.00 percentile latency (ns):1.7262256186e+10 90.00 percentile latency (ns):1.9659521727e+10 95.00 percentile latency (ns):2.0100803434e+10 97.00 percentile latency (ns):2.0256134523e+10 99.00 percentile latency (ns):2.0441735627e+10 99.90 percentile latency (ns):2.0531572606e+10 Max latency (ns):2.0531572606e+10 Mean latency (ns):1.6889626007e+10 Min latency (ns):1.2087032686e+10 Samples per second:1196.99]
--- PASS: TestParseValue (0.00s)
=== RUN   TestGetPerformanceValue
PKey: Samples per second, Pvalue: 1196.99
--- PASS: TestGetPerformanceValue (0.00s)
PASS
ok  	command-line-arguments	1.209s

 > go test -v parser/fmwork_test.go
=== RUN   TestParseValue
Values: map[Tokens per iteration:2 avg ms/token:17.369209871 avg s/iter:0.03473842 avg seqs/s:28.786571393 avg tokens/s:57.573142786 max ms/token:579.050555 max s/iter:1.15810111 max seqs/s:0.863482464 max tokens/s:1.726964928 med ms/token:15.91811675 med s/iter:0.031836234 med seqs/s:31.410750898 med tokens/s:62.821501796 min ms/token:15.857538 min s/iter:0.031715076 min seqs/s:31.530745819 min tokens/s:63.061491639 p95 ms/token:16.045740625 p95 s/iter:0.032091481 p95 seqs/s:31.16091751 p95 tokens/s:62.32183502 std s/iter:0.056241701]
--- PASS: TestParseValue (0.00s)
=== RUN   TestGetPerformanceValue
PKey: p95 s/iter, Pvalue: 0.03
--- PASS: TestGetPerformanceValue (0.00s)
PASS
ok  	command-line-arguments	0.120s
```

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>