### PR TITLE
remove hard code namespace on rolebinding creation

### DIFF
--- a/controllers/benchmarkoperator_controller.go
+++ b/controllers/benchmarkoperator_controller.go
@@ -202,7 +202,7 @@ func (r *BenchmarkOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				rbacv1.Subject{
 					Kind:      "ServiceAccount",
 					Name:      "cpe-operator-controller-manager",
-					Namespace: "cpe-operator-system",
+					Namespace: operatorNamespace,
 				},
 			},
 			RoleRef: roleRef,


### PR DESCRIPTION
This PR removes the hard code of the operator namespace when creating the clusterrolebinding for the CR of the newly-added benchmark operator. 

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>