### PR TITLE
remove neccessity of pushgateway on ReqPushLog

### DIFF
--- a/cpe-parser/api.go
+++ b/cpe-parser/api.go
@@ -184,18 +184,16 @@ func ReqPushLog(w http.ResponseWriter, r *http.Request) {
 				status = "ERROR"
 				msg = fmt.Sprintf("%v", err)
 			} else {
-				err := common.PushValues(logSpec.Parser, logSpec.ClusterID, logSpec.Instance, logSpec.BenchmarkName, logSpec.JobName, logSpec.PodName, logSpec.ConstLabels, values)
-				if err != nil {
-					status = "ERROR"
-					msg = fmt.Sprintf("%v", err)
-					pkey = ppkey
-					pval = ppval
-				} else {
-					status = "OK"
-					msg = fmt.Sprintf("%v", logSpec.ConstLabels)
-					pkey = ppkey
-					pval = ppval
+				if common.PushgatewayURL != "" {
+					err := common.PushValues(logSpec.Parser, logSpec.ClusterID, logSpec.Instance, logSpec.BenchmarkName, logSpec.JobName, logSpec.PodName, logSpec.ConstLabels, values)
+					if err != nil {
+						fmt.Println("cannot push values to push gateway: ", err)
+					}
 				}
+				status = "OK"
+				msg = fmt.Sprintf("%v", logSpec.ConstLabels)
+				pkey = ppkey
+				pval = ppval
 			}
 		}
 	}

--- a/cpe-parser/common/pusher.go
+++ b/cpe-parser/common/pusher.go
@@ -16,7 +16,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/push"
 )
 
-var pushgatewayURL string = os.Getenv("PUSHGATEWAY_URL")
+var PushgatewayURL string = os.Getenv("PUSHGATEWAY_URL")
 
 func relabelKey(key string) string {
 	key = strings.ToLower(key)
@@ -124,7 +124,7 @@ func GetGauges(parserKey string, instance string, podName string, values map[str
 }
 
 func PushValues(parserKey string, clusterID string, instance string, benchmarkName string, jobName string, podName string, const_labels map[string]string, values map[string]interface{}) error {
-	if pushgatewayURL == "" {
+	if PushgatewayURL == "" {
 		return fmt.Errorf("No PUSHGATEWAY_URL set")
 	}
 
@@ -135,7 +135,7 @@ func PushValues(parserKey string, clusterID string, instance string, benchmarkNa
 	})
 	completionTime.SetToCurrentTime()
 
-	pusher := push.New(pushgatewayURL, jobName)
+	pusher := push.New(PushgatewayURL, jobName)
 	for _, gauge := range gauges {
 		pusher.Collector(gauge)
 	}


### PR DESCRIPTION
This PR allows parser to return result even if it cannot push results to the push gateway.

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>

